### PR TITLE
Add chunk index info for RAG sources

### DIFF
--- a/backend/open_webui/retrieval/utils.py
+++ b/backend/open_webui/retrieval/utils.py
@@ -603,6 +603,10 @@ def get_sources_from_files(
                         "source": context["file"],
                         "document": context["documents"][0],
                         "metadata": context["metadatas"][0],
+                        "indices": [
+                            meta.get("chunk_index", idx)
+                            for idx, meta in enumerate(context["metadatas"][0])
+                        ],
                     }
                     if "distances" in context and context["distances"]:
                         source["distances"] = context["distances"][0]

--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -1167,6 +1167,7 @@ def save_docs_to_vector_db(
         {
             **doc.metadata,
             **(metadata if metadata else {}),
+            "chunk_index": idx,
             "embedding_config": json.dumps(
                 {
                     "engine": request.app.state.config.RAG_EMBEDDING_ENGINE,
@@ -1174,7 +1175,7 @@ def save_docs_to_vector_db(
                 }
             ),
         }
-        for doc in docs
+        for idx, doc in enumerate(docs)
     ]
 
     # ChromaDB does not like datetime formats

--- a/backend/open_webui/utils/middleware.py
+++ b/backend/open_webui/utils/middleware.py
@@ -939,9 +939,11 @@ async def process_chat_payload(request, form_data, user, metadata, model):
                     )
                     if citation_id not in citation_idx:
                         citation_idx[citation_id] = len(citation_idx) + 1
+                    chunk_idx = doc_meta.get("chunk_index")
                     context_string += (
                         f'<source id="{citation_idx[citation_id]}"'
                         + (f' name="{source_name}"' if source_name else "")
+                        + (f' chunk="{chunk_idx}"' if chunk_idx is not None else "")
                         + f">{doc_context}</source>\n"
                     )
 
@@ -1865,6 +1867,12 @@ async def process_chat_response(
                                                         ] += delta_arguments
 
                                     value = delta.get("content")
+                                    if value:
+                                        value = re.sub(
+                                            r"§text\s*(\d+)§",
+                                            lambda m: f':::CustomText {"pdf_path": "path/to/pdf", "page": {m.group(1)}}:::',
+                                            value,
+                                        )
 
                                     reasoning_content = (
                                         delta.get("reasoning_content")


### PR DESCRIPTION
## Summary
- keep track of chunk index when storing documents in RAG collections
- include chunk indices when building sources list
- annotate `<source>` tags with chunk numbers
- convert `§text n§` patterns in streamed responses to `:::CustomText {"pdf_path": "path/to/pdf", "page": n}`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'test.util')*
- `npm run lint:backend` *(fails: pylint not found)*


------
https://chatgpt.com/codex/tasks/task_e_684fddb658288327b3d46afd72a04305